### PR TITLE
fix examples/scripts/train_sft_llama.sh

### DIFF
--- a/examples/scripts/train_sft_llama.sh
+++ b/examples/scripts/train_sft_llama.sh
@@ -19,7 +19,7 @@ read -r -d '' training_commands <<EOF
     --bf16 \
     --flash_attn \
     --learning_rate 5e-6 \
-    --gradient_checkpointing \
+    --gradient_checkpointing
 EOF
     # --wandb [WANDB_TOKENS]
 


### PR DESCRIPTION
While executing the script `train_sft_llama.sh`, I encountered an error 
```
train_sft_llama.sh: line 29: warning: here-document at line 3 delimited by end-of-file (wanted `EOF')
+ read -r -d '' training_commands
```

After some investigation, I found that removing the `\` before 'EOF' solved the problem, it might be a typo