### PR TITLE
Update dpo_trainer.py

### DIFF
--- a/openrlhf/trainer/dpo_trainer.py
+++ b/openrlhf/trainer/dpo_trainer.py
@@ -109,7 +109,7 @@ class DPOTrainer(ABC):
             acc_mean = 0
             loss_mean = 0
             # train
-            for chosen_ids, c_mask, reject_ids, r_mask in self.train_dataloader:
+            for chosen_ids, c_mask, reject_ids, r_mask, _ in self.train_dataloader:
                 chosen_ids = chosen_ids.squeeze(1).to(torch.cuda.current_device())
                 c_mask = c_mask.squeeze(1).to(torch.cuda.current_device())
                 reject_ids = reject_ids.squeeze(1).to(torch.cuda.current_device())
@@ -185,7 +185,7 @@ class DPOTrainer(ABC):
             )
             acc = 0
             loss_sum = 0
-            for chosen_ids, c_mask, reject_ids, r_mask in eval_dataloader:
+            for chosen_ids, c_mask, reject_ids, r_mask, _ in eval_dataloader:
                 chosen_ids = chosen_ids.squeeze(1).to(torch.cuda.current_device())
                 c_mask = c_mask.squeeze(1).to(torch.cuda.current_device())
                 reject_ids = reject_ids.squeeze(1).to(torch.cuda.current_device())


### PR DESCRIPTION
Fixed unpacking error in train_dataloader/eval_dataloader iteration

The unpacking of variables from the eval_dataloader during iteration expected four elements, but RewardDataset.collate_fn was actually returning a tuple with five elements, leading to a ValueError. This commit addresses the mismatch by ensuring that all five elements are correctly unpacked during iteration.