### PR TITLE
Fixed backward pass by ensuring loss is a scalar

### DIFF
--- a/openrlhf/models/loss.py
+++ b/openrlhf/models/loss.py
@@ -125,7 +125,8 @@ class DPOLoss(nn.Module):
 
         logits = pi_logratios - ref_logratios
         losses = -F.logsigmoid(self.beta * logits)
+        loss = losses.mean()
         chosen_rewards = self.beta * (policy_chosen_logps - reference_chosen_logps).detach()
         rejected_rewards = self.beta * (policy_rejected_logps - reference_rejected_logps).detach()
 
-        return losses, chosen_rewards, rejected_rewards
+        return loss, chosen_rewards, rejected_rewards

--- a/openrlhf/trainer/dpo_trainer.py
+++ b/openrlhf/trainer/dpo_trainer.py
@@ -109,7 +109,7 @@ class DPOTrainer(ABC):
             acc_mean = 0
             loss_mean = 0
             # train
-            for chosen_ids, c_mask, reject_ids, r_mask in self.train_dataloader:
+            for chosen_ids, c_mask, reject_ids, r_mask, _ in self.train_dataloader:
                 chosen_ids = chosen_ids.squeeze(1).to(torch.cuda.current_device())
                 c_mask = c_mask.squeeze(1).to(torch.cuda.current_device())
                 reject_ids = reject_ids.squeeze(1).to(torch.cuda.current_device())
@@ -185,7 +185,7 @@ class DPOTrainer(ABC):
             )
             acc = 0
             loss_sum = 0
-            for chosen_ids, c_mask, reject_ids, r_mask in eval_dataloader:
+            for chosen_ids, c_mask, reject_ids, r_mask, _ in eval_dataloader:
                 chosen_ids = chosen_ids.squeeze(1).to(torch.cuda.current_device())
                 c_mask = c_mask.squeeze(1).to(torch.cuda.current_device())
                 reject_ids = reject_ids.squeeze(1).to(torch.cuda.current_device())


### PR DESCRIPTION
Adjusted the DPOLoss.forward method to return a scalar loss value by applying a mean operation on the computed losses tensor. This change resolves the RuntimeError encountered during the backward pass, where PyTorch expects a scalar output for gradient calculation.