### PR TITLE
Optimize generation post processing

### DIFF
--- a/openrlhf/models/actor.py
+++ b/openrlhf/models/actor.py
@@ -81,12 +81,10 @@ class Actor(nn.Module):
 
         attention_mask = (sequences.ne(eos_token_id) & sequences.ne(pad_token_id)).to(dtype=torch.long)
         seq_length = attention_mask.size(1)
-        for i in range(attention_mask.size(0)):
-            for t in reversed(range(seq_length)):
-                if attention_mask[i][t] > 0.5:
-                    attention_mask[i][min(t + 1, seq_length - 1)] = True
-                    sequences[i][min(t + 1, seq_length - 1)] = eos_token_id
-                    break
+
+        eos_indices = seq_length - attention_mask.fliplr().argmax(dim=1, keepdim=True).clamp(min=1)
+        attention_mask.scatter_(dim=1, index=eos_indices, value=1)
+        sequences.scatter_(dim=1, index=eos_indices, value=eos_token_id)
 
         input_len = input_ids.size(1)
         action_seq = sequences[:, input_len:-1]


### PR DESCRIPTION
Use tensor operation instead of nested python for loop.

Benchmark on batch size of 32 and sequence length of 2048:
```python
import torch
from torch.utils.benchmark import Timer

def original(attention_mask, sequences):
    seq_length = attention_mask.size(1)
    for i in range(attention_mask.size(0)):
        for t in reversed(range(seq_length)):
            if attention_mask[i][t] > 0.5:
                attention_mask[i][min(t + 1, seq_length - 1)] = True
                sequences[i][min(t + 1, seq_length - 1)] = eos_token_id
                break
    return sequences, attention_mask

def optimized(attention_mask, sequences):
    seq_length = attention_mask.size(1)
    eos_indices = seq_length - attention_mask.fliplr().argmax(dim=1, keepdim=True).clamp(min=1)
    attention_mask.scatter_(dim=1, index=eos_indices, value=1)
    sequences.scatter_(dim=1, index=eos_indices, value=eos_token_id)
    return sequences, attention_mask

eos_token_id = 2
input_len = 1024
attention_mask = torch.zeros(32, 2048, dtype=torch.long, device='cuda')
attention_mask[:, 512:1536] = 1
sequences = torch.full((32, 2048), fill_value=100, dtype=torch.long, device='cuda')

# correctness
org_seq, org_attn_mask = original(attention_mask, sequences)
opt_seq, opt_attn_mask = optimized(attention_mask, sequences)
assert (org_seq == opt_seq).all() and (org_attn_mask == opt_attn_mask).all()

print(Timer("original(attention_mask, sequences)", globals=globals()).timeit(10))
print(Timer("optimized(attention_mask, sequences)", globals=globals()).timeit(10))
```

Results:
```
<torch.utils.benchmark.utils.common.Measurement object at 0x7fc299c54310>
original(attention_mask, sequences)
  465.31 ms
  1 measurement, 10 runs , 1 thread
<torch.utils.benchmark.utils.common.Measurement object at 0x7fc299c54610>
optimized(attention_mask, sequences)
  60.89 us
  1 measurement, 10 runs , 1 thread
```