### PR TITLE
Repair parquet file reading issue in utils.py

### DIFF
--- a/openrlhf/utils/utils.py
+++ b/openrlhf/utils/utils.py
@@ -119,7 +119,7 @@ def blending_datasets(
                 data_type = os.path.splitext(files[0])[1][1:] if len(script) != 1 else script[0]
                 if data_type.endswith(".py"):
                     files = None
-                    
+
             if data_type == "json" or data_type == "jsonl":
                 data_type = "json"
             elif data_type == "txt":

--- a/openrlhf/utils/utils.py
+++ b/openrlhf/utils/utils.py
@@ -119,11 +119,13 @@ def blending_datasets(
                 data_type = os.path.splitext(files[0])[1][1:] if len(script) != 1 else script[0]
                 if data_type.endswith(".py"):
                     files = None
-
+                    
             if data_type == "json" or data_type == "jsonl":
                 data_type = "json"
             elif data_type == "txt":
                 data_type = "text"
+            elif data_type in ["parquet", "csv"]:
+                data_type = data_type
             else:
                 strategy.print(f"Unsupported file types: {data_type}")
 


### PR DESCRIPTION
The dataset complains `Unsupported file types: parquet` which is misleading.

Also https://github.com/OpenLLMAI/OpenRLHF/compare/main...tsaoyu:OpenRLHF:patch-1#diff-6e5df94c43d3630b7bab08546e9fb0161793683ec823ab627e3858783907e407L144 looks very suspicious to me. 