### PR TITLE
Fix flash attention option

### DIFF
--- a/openrlhf/models/actor.py
+++ b/openrlhf/models/actor.py
@@ -32,9 +32,12 @@ class Actor(nn.Module):
                     pretrain_or_model,
                     torch_dtype="auto",
                     trust_remote_code=True,
+                )
+                self.model = AutoModelForCausalLM.from_config(
+                    config,
+                    trust_remote_code=True,
                     use_flash_attention_2=use_flash_attention_2,
                 )
-                self.model = AutoModelForCausalLM.from_config(config, trust_remote_code=True)
             else:
                 self.model = AutoModelForCausalLM.from_pretrained(
                     pretrain_or_model,

--- a/openrlhf/models/critic.py
+++ b/openrlhf/models/critic.py
@@ -27,9 +27,12 @@ class Critic(nn.Module):
                     pretrain_or_model,
                     torch_dtype="auto",
                     trust_remote_code=True,
+                )
+                self.model = AutoModelForCausalLM.from_config(
+                    config,
+                    trust_remote_code=True,
                     use_flash_attention_2=use_flash_attention_2,
                 )
-                self.model = AutoModelForCausalLM.from_config(config, trust_remote_code=True)
             else:
                 self.model = AutoModelForCausalLM.from_pretrained(
                     pretrain_or_model,

--- a/openrlhf/models/reward_model.py
+++ b/openrlhf/models/reward_model.py
@@ -27,9 +27,12 @@ class RewardModel(nn.Module):
                     pretrain_or_model,
                     torch_dtype="auto",
                     trust_remote_code=True,
+                )
+                self.model = AutoModelForCausalLM.from_config(
+                    config,
+                    trust_remote_code=True,
                     use_flash_attention_2=use_flash_attention_2,
                 )
-                self.model = AutoModelForCausalLM.from_config(config, trust_remote_code=True)
             else:
                 self.model = AutoModelForCausalLM.from_pretrained(
                     pretrain_or_model,


### PR DESCRIPTION
The main branch did not use flash attention in RLHF training at all, even if you specify `--flash_attn`.

`AutoConfig.from_pretrained` does not respect the `use_flash_attention_2` option. `AutoModelForCausalLM.from_config` or `AutoModelForCausalLM.from_pretrained` does.
