### PR TITLE
Fix get_strategy

### DIFF
--- a/openrlhf/utils/utils.py
+++ b/openrlhf/utils/utils.py
@@ -43,6 +43,7 @@ def get_strategy(args):
         micro_train_batch_size=getattr(args, "micro_train_batch_size", 1),
         train_batch_size=getattr(args, "train_batch_size", 128),
         zero_stage=args.zero_stage,
+        bf16=getattr(args, "bf16", True),
         args=args,
     )
     return strategy


### PR DESCRIPTION
The current implementation does not pass the bf16 option as an argument, and it is always in a state of being True. 
I will modify it to pass bf16 as an argument.





