### PR TITLE
Use existing wandb login if available.

### DIFF
--- a/openrlhf/trainer/dpo_trainer.py
+++ b/openrlhf/trainer/dpo_trainer.py
@@ -65,7 +65,8 @@ class DPOTrainer(ABC):
             import wandb
 
             self._wandb = wandb
-            wandb.login(key=strategy.args.use_wandb)
+            if not wandb.api.api_key:
+                wandb.login(key=strategy.args.use_wandb)
             wandb.init(
                 entity=strategy.args.wandb_org,
                 project=strategy.args.wandb_project,

--- a/openrlhf/trainer/kto_trainer.py
+++ b/openrlhf/trainer/kto_trainer.py
@@ -68,7 +68,8 @@ class KTOTrainer(ABC):
             import wandb
 
             self._wandb = wandb
-            wandb.login(key=strategy.args.use_wandb)
+            if not wandb.api.api_key:
+                wandb.login(key=strategy.args.use_wandb)
             wandb.init(
                 entity=strategy.args.wandb_org,
                 project=strategy.args.wandb_project,

--- a/openrlhf/trainer/ppo_trainer.py
+++ b/openrlhf/trainer/ppo_trainer.py
@@ -129,7 +129,8 @@ class PPOTrainer(ABC):
             import wandb
 
             self._wandb = wandb
-            wandb.login(key=strategy.args.use_wandb)
+            if not wandb.api.api_key:
+                wandb.login(key=strategy.args.use_wandb)
             wandb.init(
                 entity=strategy.args.wandb_org,
                 project=strategy.args.wandb_project,

--- a/openrlhf/trainer/rm_trainer.py
+++ b/openrlhf/trainer/rm_trainer.py
@@ -69,7 +69,8 @@ class RewardModelTrainer(ABC):
             import wandb
 
             self._wandb = wandb
-            wandb.login(key=strategy.args.use_wandb)
+            if not wandb.api.api_key:
+                wandb.login(key=strategy.args.use_wandb)
             wandb.init(
                 entity=strategy.args.wandb_org,
                 project=strategy.args.wandb_project,

--- a/openrlhf/trainer/sft_trainer.py
+++ b/openrlhf/trainer/sft_trainer.py
@@ -66,7 +66,8 @@ class SFTTrainer(ABC):
             import wandb
 
             self._wandb = wandb
-            wandb.login(key=strategy.args.use_wandb)
+            if not wandb.api.api_key:
+                wandb.login(key=strategy.args.use_wandb)
             wandb.init(
                 entity=strategy.args.wandb_org,
                 project=strategy.args.wandb_project,


### PR DESCRIPTION
Currently wandb logging is enabled by passing a wandb API key as a CLI argument. However, that makes it easy to accidentally commit an API key as part of a shell script. It is also not necessary, as wandb stores API keys systemwide after running `wandb login` on the command line. 

This PR makes a minimal change to only run `wandb.login()` in Python if the user is not already logged in. The effect is that you can just pass `--use_wandb True` (or any value) instead of `--use_wandb ....api_key...` if you're already logged in. However, if you are _not_ already logged in, this PR does not break things, and will still accept an API key through the CLI argument.

(The only thing I can see that this could possibly break is if you are logged in into one wandb account, and tried to pass an API key for a different wandb account. I don't know if this is a concern?)