### PR TITLE
Fixed error due to 'margin' variable type being list in rm_trainer.py

### DIFF
--- a/openrlhf/trainer/rm_trainer.py
+++ b/openrlhf/trainer/rm_trainer.py
@@ -200,7 +200,7 @@ class RewardModelTrainer(ABC):
                 c_mask = c_mask.squeeze(1).to(torch.cuda.current_device())
                 reject_ids = reject_ids.squeeze(1).to(torch.cuda.current_device())
                 r_mask = r_mask.squeeze(1).to(torch.cuda.current_device())
-                margin = margin.to(torch.cuda.current_device())
+                margin = torch.tensor(margin).to(torch.cuda.current_device())
 
                 chosen_reward, reject_reward, _ = self.concatenated_forward(
                     self.model, chosen_ids, c_mask, reject_ids, r_mask


### PR DESCRIPTION
While training the reward model using train_rm_llama.sh, an error occurred:

```
    self.save_logs_and_checkpoints(args, global_step, step_bar, logs_dict)
  File "***/OpenRLHF/openrlhf/trainer/rm_trainer.py", line 180, in save_logs_and_checkpoints
    self.evaluate(self.eval_dataloader, global_step)
  File "***/OpenRLHF/openrlhf/trainer/rm_trainer.py", line 203, in evaluate
    margin = margin.to(torch.cuda.current_device())
             ^^^^^^^^^
AttributeError: 'list' object has no attribute 'to'
```

Should be fixed by updating the code to
```    margin = torch.tensor(margin).to(torch.cuda.current_device())```
like in the ```self.fit(self, args)``` function above.