### PR TITLE
fix num_training_steps when micro rollout and train size are not equal

### DIFF
--- a/examples/train_ppo.py
+++ b/examples/train_ppo.py
@@ -141,7 +141,12 @@ def train(args):
         pretrain_dataloader = None
 
     # configure scheduler
-    num_update_steps_per_episodes = len(prompts_dataloader) * args.max_epochs // strategy.accumulated_gradient
+    num_update_steps_per_episodes = (
+        int(len(prompts_dataloader) * (args.micro_rollout_batch_size / args.micro_train_batch_size))
+        * args.max_epochs
+        // strategy.accumulated_gradient
+    )
+
     max_steps = math.ceil(args.num_episodes * num_update_steps_per_episodes)
 
     actor_scheduler = get_scheduler(

--- a/openrlhf/trainer/ray/ppo_actor.py
+++ b/openrlhf/trainer/ray/ppo_actor.py
@@ -187,7 +187,12 @@ class ActorModelRayActor(BasePPORole):
         )
 
         # configure scheduler
-        num_update_steps_per_episodes = len(self.prompts_dataloader) * args.max_epochs // strategy.accumulated_gradient
+        num_update_steps_per_episodes = (
+            int(len(self.prompts_dataloader) * (args.micro_rollout_batch_size / args.micro_train_batch_size))
+            * args.max_epochs
+            // strategy.accumulated_gradient
+        )
+
         max_steps = math.ceil(args.num_episodes * num_update_steps_per_episodes)
         self.max_steps = max_steps
 


### PR DESCRIPTION
```python
len(prompts_dataloader) == prompts // micro_rollout_batch_size
```
When micro_rollout_batch_size and micro_train_batch_size are not equal, the num_update_steps_per_episodes is not correct and will cause cosine learning rate scheduler not work as expected.