### PR TITLE
vllm 0.4.1 compatibility

### DIFF
--- a/openrlhf/trainer/ray/vllm_engine.py
+++ b/openrlhf/trainer/ray/vllm_engine.py
@@ -31,12 +31,18 @@ class LLMRayActor:
 
             vllm.engine.llm_engine.set_cuda_visible_devices = _set_cuda_visible_devices
 
+        if vllm.__version__ >= "0.4.1":
+            kwargs["worker_use_ray"] = True
         self.llm = vllm.LLM(*args, **kwargs)
 
     def generate(self, *args, **kwargs):
         return self.llm.generate(*args, **kwargs)
 
     def init_process_group(self, master_address, master_port, rank_offset, world_size, group_name):
+        if vllm.__version__ >= "0.4.1":
+            return self.llm.llm_engine.model_executor._run_workers(
+                "init_process_group", master_address, master_port, rank_offset, world_size, group_name
+            )
         return self.llm.llm_engine._run_workers(
             "init_process_group", master_address, master_port, rank_offset, world_size, group_name
         )

--- a/openrlhf/trainer/ray/vllm_worker_wrap.py
+++ b/openrlhf/trainer/ray/vllm_worker_wrap.py
@@ -2,7 +2,6 @@ import importlib
 import inspect
 
 import torch
-from vllm.model_executor.weight_utils import hf_model_weights_iterator
 from vllm.worker.worker import Worker
 
 from openrlhf.utils.distributed_util import init_process_group
@@ -11,41 +10,43 @@ from openrlhf.utils.logging import init_logger
 logger = init_logger(__name__)
 
 
-def _hf_model_weights_iterator_wrap(model_name_or_path, *args, **kwargs):
-    if isinstance(model_name_or_path, dict):
-        for name, param in model_name_or_path.items():
-            yield name, param
-    else:
-        yield from hf_model_weights_iterator(model_name_or_path, *args, **kwargs)
-
-
 class WorkerWrap(Worker):
     def __init__(self, *args, **kwargs):
         # Monkey patch hf_model_weights_iterator to allow update single weight
         import vllm
 
-        if vllm.__version__ < "0.2.5":
-            import vllm.model_executor.models
+        if vllm.__version__ < "0.4.1":
+            from vllm.model_executor.weight_utils import hf_model_weights_iterator
 
-            modules = inspect.getmembers(vllm.model_executor.models, inspect.ismodule)
-            for _, m in modules:
-                m.hf_model_weights_iterator = _hf_model_weights_iterator_wrap
-        else:
-            # NOTE: In 0.2.5, vLLM introduce lazy model loader
-            # https://github.com/vllm-project/vllm/pull/2044
-            from vllm.model_executor.models import _MODELS, ModelRegistry
+            def _hf_model_weights_iterator_wrap(model_name_or_path, *args, **kwargs):
+                if isinstance(model_name_or_path, dict):
+                    for name, param in model_name_or_path.items():
+                        yield name, param
+                else:
+                    yield from hf_model_weights_iterator(model_name_or_path, *args, **kwargs)
 
-            load_model_cls = ModelRegistry.load_model_cls
+            if vllm.__version__ < "0.2.5":
+                import vllm.model_executor.models
 
-            def patched_load_model_cls(model_arch: str):
-                module_name, _ = _MODELS[model_arch]
-                module = importlib.import_module(f"vllm.model_executor.models.{module_name}")
-                module.hf_model_weights_iterator = _hf_model_weights_iterator_wrap
-                logger.info(f"Monkey patch hf_model_weights_iterator for module {module_name}")
+                modules = inspect.getmembers(vllm.model_executor.models, inspect.ismodule)
+                for _, m in modules:
+                    m.hf_model_weights_iterator = _hf_model_weights_iterator_wrap
+            else:
+                # NOTE: In 0.2.5, vLLM introduce lazy model loader
+                # https://github.com/vllm-project/vllm/pull/2044
+                from vllm.model_executor.models import _MODELS, ModelRegistry
 
-                return load_model_cls(model_arch)
+                load_model_cls = ModelRegistry.load_model_cls
 
-            ModelRegistry.load_model_cls = patched_load_model_cls
+                def patched_load_model_cls(model_arch: str):
+                    module_name, _ = _MODELS[model_arch]
+                    module = importlib.import_module(f"vllm.model_executor.models.{module_name}")
+                    module.hf_model_weights_iterator = _hf_model_weights_iterator_wrap
+                    logger.info(f"Monkey patch hf_model_weights_iterator for module {module_name}")
+
+                    return load_model_cls(model_arch)
+
+                ModelRegistry.load_model_cls = patched_load_model_cls
 
         super().__init__(*args, **kwargs)
 


### PR DESCRIPTION
vllm 0.4.1 refactors model loading, this PR updates OpenRLHF to be compatible with the changes.

Monkey patching the model weights iterator is no longer necessary, and some imports change slightly.