### PR TITLE
train_rm apply custom tokenizer chat template

### DIFF
--- a/examples/train_rm.py
+++ b/examples/train_rm.py
@@ -167,6 +167,7 @@ if __name__ == "__main__":
     parser.add_argument("--rejected_key", type=str, default=None)
     parser.add_argument("--input_template", type=str, default="Human: {}\nAssistant: ")
     parser.add_argument("--apply_chat_template", action="store_true", default=False)
+    parser.add_argument("--tokenizer_chat_template", type=str, default=None)
 
     # wandb pamameters
     parser.add_argument("--use_wandb", type=str, default=None)

--- a/openrlhf/datasets/reward_dataset.py
+++ b/openrlhf/datasets/reward_dataset.py
@@ -103,6 +103,9 @@ class RewardDataset(Dataset):
         apply_chat_template = getattr(self.strategy.args, "apply_chat_template", False)
         if apply_chat_template:
             apply_chat_template = self.tokenizer.apply_chat_template
+            tokenizer_chat_template = getattr(self.strategy.args, "tokenizer_chat_template", None)
+            if tokenizer_chat_template:
+                self.tokenizer.chat_template = tokenizer_chat_template
 
         for data in tqdm(dataset, disable=not self.strategy.is_rank_0()):
             prompt, chosen, reject, margin = preprocess_data(


### PR DESCRIPTION
I have a use case where I need to train RM from the base model, it would be helpful to be able to add a chat template here too. Copy paste from train_sft.py.